### PR TITLE
WL-3675 Corrected alert messages and now user can update email to an

### DIFF
--- a/user-tool/tool/src/bundle/admin.properties
+++ b/user-tool/tool/src/bundle/admin.properties
@@ -22,8 +22,8 @@ useedi.emailbaddomain = It has not been possible to update the email address for
                         to this address then you should login using your {1}.
 
 official.user.name = Official Username
-useedi.email.exists = A user account with this email Id already exists. Please choose a different one.
-useedi.val.email = A validation link has been sent to {0}. Please validate to update your UserId
+useedi.email.exists = There is already an account with this email address, are you sure you want to continue? We regret that unfortunately it is not possible to merge two or more accounts.
+useedi.val.email = We recommend that you update your User Id to match your new email address. To do this please click on the link in the validation email which has been sent to {0}.  If you do not wish to change your User Id then please ignore the email.
 
 #merged all duplicates- SAK-18304
 useconrem.alert   = Alert:

--- a/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
+++ b/user-tool/tool/src/java/org/sakaiproject/user/tool/UsersAction.java
@@ -1120,8 +1120,12 @@ public class UsersAction extends PagedResourceActionII
 		UserEdit user = (UserEdit) state.getAttribute("user");
 			try {
 				UserDirectoryService.getUserByEid(email);
-				addAlert(state,rb.getString("useedi.email.exists"));
-				return false;
+				//If we have shown this 'email exists' message once and user still wants to create account with the same email address, continue with the process
+				String alertMessage = StringUtils.trimToNull(data.getParameters().getString("alert_message"));
+				if(!(alertMessage != null && alertMessage.equals(rb.getString("useedi.email.exists")))){
+					addAlert(state,rb.getString("useedi.email.exists"));
+					return false;
+				}
 			} catch (UserNotDefinedException e) {
 				//unique user ,so continue
 			}

--- a/user-tool/tool/src/webapp/vm/user/chef_users_edit.vm
+++ b/user-tool/tool/src/webapp/vm/user/chef_users_edit.vm
@@ -90,9 +90,9 @@ function removeOptionalAttributeBlock(elem) {
 					$tlang.getString("useconrem.ema")
 				</label>
 			#if ($service.allowUpdateUserEmail($user.Id) || !$user)
-				<input type="text" name="email" id="email"#if($user)value="$validator.escapeHtml($user.Email)"#elseif($valueEmail)value="$validator.escapeHtml($valueEmail)"#end />
+				<input type="text" name="email" id="email"#if($valueEmail)value="$validator.escapeHtml($valueEmail)"#elseif($user)value="$validator.escapeHtml($user.Email)"#end />
 			#else
-				#if($user)$validator.escapeHtml($user.Email)#elseif($valueEmail)$validator.escapeHtml($valueEmail)#end
+				#if($valueEmail)$validator.escapeHtml($valueEmail)#elseif($user)$validator.escapeHtml($user.Email)#end
 			#end
 			</p>	
 #if ($incPw)
@@ -222,6 +222,7 @@ function removeOptionalAttributeBlock(elem) {
 				<input type="submit" name="eventSubmit_doCancel" value="$tlang.getString("useedi.can")" accesskey="x" />
 			</div>
 			<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+			<input type="hidden" name="alert_message" id="alert_message" value="$alertMessage" />
 		</form>
 	</div>
 


### PR DESCRIPTION
existing one.

Added check in the method 'readUserForm' for 'email exists' alert and if
it exists means user wants to continue with the existing email address.
