### PR TITLE
WL-4250 Users can change the password in Accounts tool.

### DIFF
--- a/user-tool/tool/src/bundle/admin.properties
+++ b/user-tool/tool/src/bundle/admin.properties
@@ -22,7 +22,7 @@ useedi.emailbaddomain = It has not been possible to update the email address for
                         to this address then you should login using your {1}.
 
 official.user.name = Official Username
-useedi.email.exists = There is already an account with this email address, are you sure you want to continue? We regret that unfortunately it is not possible to merge two or more accounts.
+useedi.email.exists = There is already an account with this email address.
 useedi.val.email = We recommend that you update your User Id to match your new email address. To do this please click on the link in the validation email which has been sent to {0}.  If you do not wish to change your User Id then please ignore the email.
 
 #merged all duplicates- SAK-18304


### PR DESCRIPTION
Now no two external users can have same email address, kept the unique
email functionality as 'password-rest' tool will not work otherwise.
In  UserAction class checking for email change by user before actually
checking for existing account with the new email.
Similarly, creating validation account only if email is changed to a new
unique email address.
